### PR TITLE
#15 InfoPanel's Course and Topic TextFields are limited to 50 character now

### DIFF
--- a/client/src/modules/InfoPanel.jsx
+++ b/client/src/modules/InfoPanel.jsx
@@ -59,6 +59,7 @@ const InfoPanel = () => {
             Course
           </Typography>
           <TextField
+            inputProps={{ maxLength: 50 }}
             fullWidth
             variant="outlined"
             id="course-height-input"
@@ -96,6 +97,7 @@ const InfoPanel = () => {
             Topic
           </Typography>
           <TextField
+            inputProps={{ maxLength: 50 }}
             fullWidth
             variant="outlined"
             id="topic-input"


### PR DESCRIPTION
I added inputProps={{ maxLength: 50 }} to Course and Topic TextFields to prevent more than 50 character for each

showCase
![limitedTextFields](https://user-images.githubusercontent.com/79264045/233436280-e53a74b4-91f3-469f-b2b4-fa382a60ffa1.png)
